### PR TITLE
Add .xcuserstate files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 octrace.xcodeproj/xcuserdata/
+octrace.xcodeproj/project.xcworkspace/xcuserdata
 octrace.xcworkspace/
 Pods/
-


### PR DESCRIPTION
Every new project opening generates new `.xcuserstate` file. Maybe we can silence it by adding to `gitignore`?