### PR TITLE
Add dynamic text size support

### DIFF
--- a/octrace/Base.lproj/Main.storyboard
+++ b/octrace/Base.lproj/Main.storyboard
@@ -55,7 +55,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="5jj-b3-b9S"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Record contact"/>
                                 <connections>
@@ -103,6 +103,7 @@
                                     <constraint firstAttribute="width" constant="40" id="2Dh-u0-AgU"/>
                                     <constraint firstAttribute="height" constant="40" id="v9a-tM-9r8"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="tintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <state key="normal" image="outline_bluetooth_black_24pt">
                                     <color key="titleColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -118,6 +119,7 @@
                                     <constraint firstAttribute="height" constant="40" id="eXF-xp-uOi"/>
                                     <constraint firstAttribute="width" constant="40" id="iXW-NW-l0e"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="tintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <state key="normal" title="D">
                                     <color key="titleColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -183,16 +185,16 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="tR4-ym-Vok"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="STATUS CHANGE"/>
                                 <connections>
                                     <action selector="statusChange:" destination="6ld-MF-qcp" eventType="touchUpInside" id="qxM-pU-XIV"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CURRENT STATUS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fqn-M2-hsL">
-                                <rect key="frame" x="119.5" y="368.5" width="175" height="25.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CURRENT STATUS" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fqn-M2-hsL">
+                                <rect key="frame" x="20" y="367.5" width="374" height="26.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -200,7 +202,9 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="tVG-dr-mgC" firstAttribute="centerY" secondItem="c4l-F0-NZf" secondAttribute="centerY" id="5Qa-W5-sKm"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="fqn-M2-hsL" secondAttribute="trailing" id="Fnp-9h-Ltt"/>
                             <constraint firstItem="tVG-dr-mgC" firstAttribute="leading" secondItem="Swx-qk-Fcc" secondAttribute="leading" constant="32" id="GLS-IB-CMX"/>
+                            <constraint firstItem="fqn-M2-hsL" firstAttribute="leading" secondItem="c4l-F0-NZf" secondAttribute="leadingMargin" id="WKc-6n-78K"/>
                             <constraint firstItem="Swx-qk-Fcc" firstAttribute="trailing" secondItem="tVG-dr-mgC" secondAttribute="trailing" constant="32" id="ddc-Je-yGW"/>
                             <constraint firstItem="fqn-M2-hsL" firstAttribute="centerX" secondItem="c4l-F0-NZf" secondAttribute="centerX" id="iCf-sD-sig"/>
                             <constraint firstItem="tVG-dr-mgC" firstAttribute="top" secondItem="fqn-M2-hsL" secondAttribute="bottom" constant="32" id="igP-kB-LIy"/>

--- a/octrace/UI/Controllers/OnboardingViewController.xib
+++ b/octrace/UI/Controllers/OnboardingViewController.xib
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,18 +23,18 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TITLE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pGo-Ce-SmP">
-                    <rect key="frame" x="32" y="108" width="350" height="43"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="36"/>
+                    <rect key="frame" x="32" y="108" width="350" height="41"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cCp-7h-dXy" customClass="RoundButton" customModule="OCTrace_DEV" customModuleProvider="target">
-                    <rect key="frame" x="32" y="756" width="350" height="44"/>
+                    <rect key="frame" x="32" y="753" width="350" height="44"/>
                     <color key="backgroundColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="Me3-l9-Qne"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <state key="normal" title="ACTION"/>
                     <connections>
@@ -43,12 +43,13 @@
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DESCRIPTION" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aef-yI-wid">
                     <rect key="frame" x="32" y="438" width="350" height="20.5"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2cb-FB-exl">
-                    <rect key="frame" x="178.5" y="816" width="57" height="30"/>
+                    <rect key="frame" x="175" y="813" width="64" height="33"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <state key="normal" title="Not now"/>
                     <connections>
                         <action selector="skipTap:" destination="-1" eventType="touchUpInside" id="SGx-0d-pT8"/>


### PR DESCRIPTION
I suggest supporting dynamic text size. For those who set the biggest text size in the device, settings will receive all those benefits in the app.
For buttons I've used **Headline** text. For other screen text I've used **body** or **Large title** styles
I've attached screenshots for the biggest font sizes (on a normal scale).
iPhone 11:
![image](https://user-images.githubusercontent.com/13601748/80799893-bc6d3500-8bb0-11ea-9ca4-1b542bad72a0.png)
![image](https://user-images.githubusercontent.com/13601748/80799905-c42cd980-8bb0-11ea-8222-d6d7e403ebe7.png)
![image](https://user-images.githubusercontent.com/13601748/80799948-ddce2100-8bb0-11ea-8a2f-c3507a0ac458.png)



**iPhone SE (2nd generation):**
![image](https://user-images.githubusercontent.com/13601748/80799978-f8a09580-8bb0-11ea-9e67-34aa3a00ee2f.png)
![image](https://user-images.githubusercontent.com/13601748/80799956-e6bef280-8bb0-11ea-94b0-1d28090a248c.png)
![image](https://user-images.githubusercontent.com/13601748/80799959-e888b600-8bb0-11ea-8e3f-2bece50465b4.png)

