### PR TITLE
dp3tsdk dependency fix + increase deploy target

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '13.5'
 
 # ignore all warnings from all pods
 inhibit_all_warnings!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Alamofire (5.2.0)
+  - Alamofire (5.2.1)
   - AlamofireNetworkActivityIndicator (3.1.0):
     - Alamofire (~> 5.1)
   - BlueCryptor (1.0.32)
   - BlueECC (1.2.5)
   - BlueRSA (1.0.34)
   - CryptoSwift (1.3.1)
-  - DP3TSDK (0.0.2):
-    - SQLite.swift (~> 0.12)
+  - DP3TSDK (0.4.0):
     - SwiftJWT (~> 3.5)
     - SwiftProtobuf (~> 1.6)
+    - ZIPFoundation (~> 0.9)
   - Firebase/Analytics (6.25.0):
     - Firebase/Core
   - Firebase/Core (6.25.0):
@@ -98,9 +98,6 @@ PODS:
   - R.swift (5.2.2):
     - R.swift.Library (~> 5.2.0)
   - R.swift.Library (5.2.0)
-  - SQLite.swift (0.12.2):
-    - SQLite.swift/standard (= 0.12.2)
-  - SQLite.swift/standard (0.12.2)
   - SwiftJWT (3.5.3):
     - BlueCryptor (~> 1.0)
     - BlueECC (~> 1.1)
@@ -109,6 +106,7 @@ PODS:
     - LoggerAPI (~> 1.7)
   - SwiftLint (0.39.2)
   - SwiftProtobuf (1.9.0)
+  - ZIPFoundation (0.9.11)
 
 DEPENDENCIES:
   - Alamofire
@@ -148,19 +146,19 @@ SPEC REPOS:
     - PromisesObjC
     - R.swift
     - R.swift.Library
-    - SQLite.swift
     - SwiftJWT
     - SwiftLint
     - SwiftProtobuf
+    - ZIPFoundation
 
 SPEC CHECKSUMS:
-  Alamofire: c1ca147559e730bfb2182c8c7aafbdd90a867987
+  Alamofire: e911732990610fe89af59ac0077f923d72dc3dfd
   AlamofireNetworkActivityIndicator: 6564782bd7b9e6c430ae67d9277af01907b01ca4
   BlueCryptor: b0aee3d9b8f367b49b30de11cda90e1735571c24
   BlueECC: 0d18e93347d3ec6d41416de21c1ffa4d4cd3c2cc
   BlueRSA: 6f9776d62d9773502415a7db3bcbb2bbb3f71fc3
   CryptoSwift: f12f037f6d0fcd6d48c96db0071b653de64e6c4d
-  DP3TSDK: b398641ec3d1232ba35d79fab6cdbf00b9d2dec5
+  DP3TSDK: b95202d4dae885bfd4dc34f76ad9f5867851f477
   Firebase: 5719b4f965f76643241a1bb8244483ff6117db39
   FirebaseAnalytics: 93565f3f0f0f50a5d8770850bfe6a82eaba5db27
   FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
@@ -180,11 +178,11 @@ SPEC CHECKSUMS:
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   R.swift: 7c52cdc57a66840ffe6cbd8a823d732059d42a32
   R.swift.Library: 5ba4f1631300caf9a4d890186930da85d540769d
-  SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   SwiftJWT: 9a47a71090cae25767078756b5810e3b630aa9a7
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   SwiftProtobuf: ecbec1be9036d15655f6b3443a1c4ea693c97932
+  ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: f1e2b9a9af45465542294547c749f41927e7d2e1
+PODFILE CHECKSUM: e0cb706b952e53724345be94abbeed953b77eaee
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.2

--- a/octrace.xcodeproj/project.pbxproj
+++ b/octrace.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		44A619811F5AC4D47CDBE5D3 /* Pods_octrace_DEV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A8BBD365D79BDF10195B3A /* Pods_octrace_DEV.framework */; };
+		136BCA1BCB61DA73517D9AA9 /* Pods_octrace_DEV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C48FC347EAAE8EF7ECA9BB5 /* Pods_octrace_DEV.framework */; };
 		B1B5D3E0245C7BA300D5D717 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5D3DF245C7BA300D5D717 /* R.generated.swift */; };
 		FA0571272446412E00D39462 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0571262446412E00D39462 /* AppDelegate.swift */; };
 		FA05712B2446412E00D39462 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA05712A2446412E00D39462 /* RootViewController.swift */; };
@@ -58,12 +58,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		117D1C6D38F63D587FA1E1BD /* Pods-octrace.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace.release.xcconfig"; path = "Target Support Files/Pods-octrace/Pods-octrace.release.xcconfig"; sourceTree = "<group>"; };
-		15CB5B50BF58601BDC235F89 /* Pods-octrace.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace.debug.xcconfig"; path = "Target Support Files/Pods-octrace/Pods-octrace.debug.xcconfig"; sourceTree = "<group>"; };
+		2C48FC347EAAE8EF7ECA9BB5 /* Pods_octrace_DEV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_octrace_DEV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A48694C919555A0ACCCC1A3D /* Pods-octrace DEV.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace DEV.debug.xcconfig"; path = "Target Support Files/Pods-octrace DEV/Pods-octrace DEV.debug.xcconfig"; sourceTree = "<group>"; };
 		B1B5D3DF245C7BA300D5D717 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
-		C1A8BBD365D79BDF10195B3A /* Pods_octrace_DEV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_octrace_DEV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C761838EBCA157C3CFEADE1F /* Pods-octrace DEV.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace DEV.release.xcconfig"; path = "Target Support Files/Pods-octrace DEV/Pods-octrace DEV.release.xcconfig"; sourceTree = "<group>"; };
-		E8132C6432B2B904E6C385FF /* Pods-octrace DEV.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace DEV.debug.xcconfig"; path = "Target Support Files/Pods-octrace DEV/Pods-octrace DEV.debug.xcconfig"; sourceTree = "<group>"; };
+		D48095734213791F57BAC5C9 /* Pods-octrace DEV.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-octrace DEV.release.xcconfig"; path = "Target Support Files/Pods-octrace DEV/Pods-octrace DEV.release.xcconfig"; sourceTree = "<group>"; };
 		FA0571232446412E00D39462 /* OCTrace DEV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OCTrace DEV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA0571262446412E00D39462 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FA05712A2446412E00D39462 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
@@ -122,7 +120,7 @@
 			files = (
 				FA057145244644DB00D39462 /* MapKit.framework in Frameworks */,
 				FA057147244644E300D39462 /* WebKit.framework in Frameworks */,
-				44A619811F5AC4D47CDBE5D3 /* Pods_octrace_DEV.framework in Frameworks */,
+				136BCA1BCB61DA73517D9AA9 /* Pods_octrace_DEV.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -134,7 +132,7 @@
 			children = (
 				FA057146244644E300D39462 /* WebKit.framework */,
 				FA057144244644DA00D39462 /* MapKit.framework */,
-				C1A8BBD365D79BDF10195B3A /* Pods_octrace_DEV.framework */,
+				2C48FC347EAAE8EF7ECA9BB5 /* Pods_octrace_DEV.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -142,10 +140,8 @@
 		EE8A3518629D67CBA90A5493 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				15CB5B50BF58601BDC235F89 /* Pods-octrace.debug.xcconfig */,
-				117D1C6D38F63D587FA1E1BD /* Pods-octrace.release.xcconfig */,
-				E8132C6432B2B904E6C385FF /* Pods-octrace DEV.debug.xcconfig */,
-				C761838EBCA157C3CFEADE1F /* Pods-octrace DEV.release.xcconfig */,
+				A48694C919555A0ACCCC1A3D /* Pods-octrace DEV.debug.xcconfig */,
+				D48095734213791F57BAC5C9 /* Pods-octrace DEV.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -285,12 +281,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA0571372446413000D39462 /* Build configuration list for PBXNativeTarget "octrace DEV" */;
 			buildPhases = (
-				9A8A38F6739D115A89B97C5B /* [CP] Check Pods Manifest.lock */,
+				63512AAB294F361728E1E0A9 /* [CP] Check Pods Manifest.lock */,
 				B1B5D3DD245C7A1200D5D717 /* Run RSwift */,
 				FA05711F2446412E00D39462 /* Sources */,
 				FA0571202446412E00D39462 /* Frameworks */,
 				FA0571212446412E00D39462 /* Resources */,
-				432B66A2517D31F1C6F9DDCF /* [CP] Embed Pods Frameworks */,
+				6A00FD2876A4A1AF4E0ABE9E /* [CP] Embed Pods Frameworks */,
 				FAEE90AB2453188D009A46E7 /* Run Swiftlint */,
 			);
 			buildRules = (
@@ -359,24 +355,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		432B66A2517D31F1C6F9DDCF /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9A8A38F6739D115A89B97C5B /* [CP] Check Pods Manifest.lock */ = {
+		63512AAB294F361728E1E0A9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -396,6 +375,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6A00FD2876A4A1AF4E0ABE9E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-octrace DEV/Pods-octrace DEV-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B1B5D3DD245C7A1200D5D717 /* Run RSwift */ = {
@@ -550,7 +546,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -604,7 +600,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -616,7 +612,7 @@
 		};
 		FA0571382446413000D39462 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E8132C6432B2B904E6C385FF /* Pods-octrace DEV.debug.xcconfig */;
+			baseConfigurationReference = A48694C919555A0ACCCC1A3D /* Pods-octrace DEV.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = octrace/OCTrace.entitlements;
@@ -625,7 +621,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = S5ENNERNQZ;
 				INFOPLIST_FILE = octrace/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -641,7 +637,7 @@
 		};
 		FA0571392446413000D39462 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C761838EBCA157C3CFEADE1F /* Pods-octrace DEV.release.xcconfig */;
+			baseConfigurationReference = D48095734213791F57BAC5C9 /* Pods-octrace DEV.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = octrace/OCTrace.entitlements;
@@ -650,7 +646,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = S5ENNERNQZ;
 				INFOPLIST_FILE = octrace/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/octrace/AppDelegate.swift
+++ b/octrace/AppDelegate.swift
@@ -73,12 +73,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let dp3tBackendUrl = URL(string: "https://dp3t.\(NetworkUtil.host)/")!
         do {
             try DP3TTracing.initialize(
-                with: .manual(
-                    .init(appId: Bundle.main.bundleIdentifier!,
-                          bucketBaseUrl: dp3tBackendUrl,
-                          reportBaseUrl: dp3tBackendUrl,
-                          jwtPublicKey: nil)
-                )
+                with: .init(appId: Bundle.main.bundleIdentifier!,
+                            bucketBaseUrl: dp3tBackendUrl,
+                            reportBaseUrl: dp3tBackendUrl,
+                            jwtPublicKey: nil)
             )
             
             DP3TTracing.delegate = self


### PR DESCRIPTION
DP3TSDK fixed the dependency issue but the thing is that this update requires latest iOS because published by Apple newest framework `ExposureNotification` requires iOS 13.5 and higher. As I remember, your initial idea was to have lower iOS version, but I cannot imagine that you won't use this framework in the project